### PR TITLE
[config]: Create portchannel with LACP key

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1375,7 +1375,7 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback):
         ctx.fail("{} already exists!".format(portchannel_name))
 
     fvs = {'admin_status': 'up',
-           'mtu': '9100'}
+           'mtu': '9100', 'lacp_key': 'auto'}
     if min_links != 0:
         fvs['min_links'] = str(min_links)
     if fallback != 'false':

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -44,7 +44,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_2_0_0'
+        self.CURRENT_VERSION = 'version_2_0_1'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -473,7 +473,22 @@ class DBMigrator():
         Current latest version. Nothing to do here.
         """
         log.log_info('Handling version_2_0_0')
+        warmreboot_state = self.stateDB.get(self.stateDB.STATE_DB, 'WARM_RESTART_ENABLE_TABLE|system', 'enable')
 
+        if warmreboot_state != 'true':
+            portchannel_table = self.configDB.get_table('PORTCHANNEL')
+            for name, data in portchannel_table.items():
+                data['lacp_key'] = 'auto'
+                self.configDB.set_entry('PORTCHANNEL', name, data)
+            self.set_version('version_2_0_1')
+
+        return 'version_2_0_1'
+
+    def version_2_0_1(self):
+        """
+        Current latest version. Nothing to do here.
+        """
+        log.log_info('Handling version_2_0_1')
         return None
 
     def get_version(self):

--- a/tests/db_migrator_input/config_db/non-default-config-expected.json
+++ b/tests/db_migrator_input/config_db/non-default-config-expected.json
@@ -1115,6 +1115,6 @@
         "speed": "50000"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_2_0_0"
+        "VERSION": "version_2_0_1"
     }
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Change LACP key to be generated from the Port Channel name instead of always being 0
#### How I did it

#### How to verify it
Create a new port-channel, add a port and run tcpdump on this port.
LACP Key should be the number in the end of the port channel name with leading 1.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

