### PR TITLE
[Mellanox] Update mellanoxs dump generation to include SDK dumps

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -766,6 +766,16 @@ collect_mellanox() {
         ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
         save_file "${mst_dump_filename}${i}" mstdump true
     done
+    
+    # Save SDK error dumps
+    local sdk_dump_path=`${CMD_PREFIX}docker exec syncd cat /tmp/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
+    if [[ $sdk_dump_path ]]; then
+        copy_from_docker syncd $sdk_dump_path  /tmp/sdk-dumps
+        for file in $(find /tmp/sdk-dumps); do
+            save_file ${file} sai_sdk_dump false
+        done
+        rm -rf /tmp/sdk-dumps
+    fi
 }
 
 ###############################################################################


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add SDK dump output into techsupport in the generate_dump script.

#### How I did it
Add a step to copy SDK dump output into techsupport in the generate_dump script.

#### How to verify it
Simulate SDK event and check that dump is copied into the techsupport results.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

