### PR TITLE
[QOS] Check if using dry_run flag before clearing qos configuration

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2505,8 +2505,9 @@ def reload(ctx, no_dynamic_buffer, dry_run, json_data, ports):
         _qos_update_ports(ctx, ports, dry_run, json_data)
         return
 
-    log.log_info("'qos reload' executing...")
-    _clear_qos()
+    if not dry_run:
+        log.log_info("'qos reload' executing...")
+        _clear_qos()
 
     _, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()
     sonic_version_file = device_info.get_sonic_version_file()


### PR DESCRIPTION
Calling config qos reload with dry_run should not affect the DB.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Stopped config qos reload from clearing the qos configuration on dry_run

#### How I did it
Added a check if we are in a dry run on the qos reload flow before clearing the QoS configuration.

#### How to verify it
Configure qos.
Run qos reload with dry run flag.
Check qos configuration is intact.

```
config qos reload
config qos reload --dry_run /tmp/buffer.json --json-data '{"DEVICE_METADATA": {"localhost": {}}}'
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

