### PR TITLE
[Secure Boot] Fix issue with fast\warm boot on devices not supporting…

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -612,9 +612,9 @@ fi
 if is_secureboot && grep -q aboot_machine= /host/machine.conf; then
     load_aboot_secureboot_kernel
 else
-    # check if secure boot is enable in UEFI 
-    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled")
-    if [ ${SECURE_UPGRADE_ENABLED} -eq 1 ]; then
+    # check if secure boot is enable in UEFI
+    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null)
+    if [[ $SECURE_UPGRADE_ENABLED =~ "Secure Boot: enabled" ]]; then
         load_kernel_secure
     else
         load_kernel


### PR DESCRIPTION
… UEFI

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix issue that caused fast & warm reboot to not work if SB is disabled or not supported.

#### How I did it
Change the way we check if SB is supported. The pervious check has thrown an error that the warm/fast script caught which cause it to run the trap. I use a different check that will not thorw an error.

#### How to verify it
Run warm or fast reboot

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

