### PR TITLE
Fix secure boot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -673,7 +673,7 @@ if is_secureboot && grep -q aboot_machine= /host/machine.conf; then
 else
     # check if secure boot is enable in UEFI
     CHECK_SECURE_UPGRADE_ENABLED=0
-    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
+    SECURE_UPGRADE_ENABLED=$(mokutil --sb-state 2>/dev/null | grep -c "enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
     if [[ CHECK_SECURE_UPGRADE_ENABLED -ne 0 ]]; then
         debug "Loading kernel without secure boot"
         load_kernel

--- a/scripts/soft-reboot
+++ b/scripts/soft-reboot
@@ -93,7 +93,7 @@ function clear_lingering_reboot_config()
     if [[ -f ${WARM_DIR}/${REDIS_FILE} ]]; then
         mv -f ${WARM_DIR}/${REDIS_FILE} ${WARM_DIR}/${REDIS_FILE}.${TIMESTAMP} || /bin/true
     fi
-    /sbin/kexec -u || /bin/true
+    /sbin/kexec -u -a || /bin/true
 }
 
 SCRIPT=$0
@@ -147,9 +147,17 @@ function setup_reboot_variables()
     fi
 }
 
+function invoke_kexec() {
+    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS" $@
+}
+
 function load_kernel() {
     # Load kernel into the memory
-    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
+    invoke_kexec -a
+}
+
+function load_kernel_secure() {
+    invoke_kexec -s
 }
 
 function reboot_pre_check()
@@ -215,7 +223,14 @@ stop_sonic_services
 
 clear_lingering_reboot_config
 
-load_kernel
+# check if secure boot is enabled 
+CHECK_SECURE_UPGRADE_ENABLED=0
+SECURE_UPGRADE_ENABLED=$(mokutil --sb-state 2>/dev/null | grep -c "enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
+if [[ CHECK_SECURE_UPGRADE_ENABLED -ne 0 ]]; then
+    load_kernel
+else
+    load_kernel_secure
+fi
 
 # Update the reboot cause file to reflect that user issued 'reboot' command
 # Upon next boot, the contents of this file will be used to determine the

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -164,7 +164,7 @@ class GrubBootloader(OnieInstallerBootloader):
             if ! [ -n "$(ls -A /sys/firmware/efi/efivars 2>/dev/null)" ]; then
                 mount -t efivarfs none /sys/firmware/efi/efivars 2>/dev/null
             fi
-            SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled")
+            SECURE_UPGRADE_ENABLED=$(mokutil --sb-state 2>/dev/null | grep -c "enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
         else
             echo "efi not supported - exiting without verification"
             exit 1

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -164,7 +164,8 @@ class GrubBootloader(OnieInstallerBootloader):
             if ! [ -n "$(ls -A /sys/firmware/efi/efivars 2>/dev/null)" ]; then
                 mount -t efivarfs none /sys/firmware/efi/efivars 2>/dev/null
             fi
-            SECURE_UPGRADE_ENABLED=$(mokutil --sb-state 2>/dev/null | grep -c "enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
+            SECURE_UPGRADE_ENABLED=$(mokutil --sb-state 2>/dev/null | \
+                grep -c "enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
         else
             echo "efi not supported - exiting without verification"
             exit 1

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -164,8 +164,7 @@ class GrubBootloader(OnieInstallerBootloader):
             if ! [ -n "$(ls -A /sys/firmware/efi/efivars 2>/dev/null)" ]; then
                 mount -t efivarfs none /sys/firmware/efi/efivars 2>/dev/null
             fi
-            SECURE_UPGRADE_ENABLED=$(mokutil --sb-state 2>/dev/null | \
-                grep -c "enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
+            SECURE_UPGRADE_ENABLED=$(mokutil --sb-state 2>/dev/null | grep -c "enabled")
         else
             echo "efi not supported - exiting without verification"
             exit 1


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Moved to use mokutil instead of bootctl as bootctl is no longer available in Bookworm.
This affected reboot scripts, and upgrade scenario.

#### How I did it


#### How to verify it
After fixing the scripts to check reboot:

root@sn5600:/home/admin# soft-reboot
+ SECURE_UPGRADE_ENABLED=1
+ [[ CHECK_SECURE_UPGRADE_ENABLED -ne 0 ]]
+ load_kernel_secure
+ invoke_kexec -s
packet_write_wait: port 22: Broken pipe

admin@sn5600:~$ show reboot-cause
User issued 'soft-reboot' command [User: admin, Time: Tue Jul 23 11:06:43 PM UTC 2024]


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

