### PR TITLE
[SPM] Add support for configuring systemd service Type in package man…

### DIFF
--- a/sonic-utilities-data/templates/sonic.service.j2
+++ b/sonic-utilities-data/templates/sonic.service.j2
@@ -25,7 +25,7 @@ StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
-{%- if manifest.service.type is defined %}
+{%- if manifest.service.type is defined and manifest.service.type %}
 Type={{ manifest.service.type }}
 {%- endif %}
 ExecStartPre={{path}}/{{manifest.service.name}}.sh start{% if multi_instance %} %i{% endif %}

--- a/sonic-utilities-data/templates/sonic.service.j2
+++ b/sonic-utilities-data/templates/sonic.service.j2
@@ -25,6 +25,9 @@ StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
+{%- if manifest.service.type is defined %}
+Type={{ manifest.service.type }}
+{%- endif %}
 ExecStartPre={{path}}/{{manifest.service.name}}.sh start{% if multi_instance %} %i{% endif %}
 ExecStart={{path}}/{{manifest.service.name}}.sh wait{% if multi_instance %} %i{% endif %}
 ExecStop={{path}}/{{manifest.service.name}}.sh stop{% if multi_instance %} %i{% endif %}

--- a/sonic_package_manager/manifest.py
+++ b/sonic_package_manager/manifest.py
@@ -203,7 +203,7 @@ class ManifestSchema:
             ManifestField('host-service', DefaultMarshaller(bool), True),
             ManifestField('delayed', DefaultMarshaller(bool), False),
             ManifestField('check_up_status', DefaultMarshaller(bool), False),
-            ManifestField('type', DefaultMarshaller(str)),
+            ManifestField('type', DefaultMarshaller(str), ''),
             ManifestRoot('warm-shutdown', [
                 ManifestArray('after', DefaultMarshaller(str)),
                 ManifestArray('before', DefaultMarshaller(str)),

--- a/sonic_package_manager/manifest.py
+++ b/sonic_package_manager/manifest.py
@@ -203,6 +203,7 @@ class ManifestSchema:
             ManifestField('host-service', DefaultMarshaller(bool), True),
             ManifestField('delayed', DefaultMarshaller(bool), False),
             ManifestField('check_up_status', DefaultMarshaller(bool), False),
+            ManifestField('type', DefaultMarshaller(str)),
             ManifestRoot('warm-shutdown', [
                 ManifestArray('after', DefaultMarshaller(str)),
                 ManifestArray('before', DefaultMarshaller(str)),


### PR DESCRIPTION
…ifests


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This change allows package developers to specify the systemd service type in their package manifests, which will be reflected in the generated systemd service files.

#### How I did it
- Add optional 'type' field to service section in manifest schema
- Update sonic.service.j2 template to conditionally include Type= directive

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

