### PR TITLE
[spm] Remove docker_image_references dependency from tests

### DIFF
--- a/sonic_package_manager/database.py
+++ b/sonic_package_manager/database.py
@@ -31,7 +31,8 @@ class PackageEntry:
         built_in: Boolean flag whether the package is built in.
         image_id: Image ID for this package or None if package
                   is not installed.
-        tag: Tag for this package or None if package is not installed.
+        docker_image_reference: Docker image reference for this package or None if package
+                                is not installed.
     """
 
     name: str
@@ -42,7 +43,7 @@ class PackageEntry:
     installed: bool = False
     built_in: bool = False
     image_id: Optional[str] = None
-    tag: Optional[str] = None
+    docker_image_reference: Optional[str] = None
 
 
 def package_from_dict(name: str, package_info: Dict) -> PackageEntry:
@@ -57,10 +58,10 @@ def package_from_dict(name: str, package_info: Dict) -> PackageEntry:
     installed = package_info.get('installed', False)
     built_in = package_info.get('built-in', False)
     image_id = package_info.get('image-id')
-    tag = package_info.get('tag')
+    docker_image_reference = package_info.get('docker-image-reference')
     return PackageEntry(name, repository, description,
                         default_reference, version, installed,
-                        built_in, image_id, tag)
+                        built_in, image_id, docker_image_reference)
 
 
 def package_to_dict(package: PackageEntry) -> Dict:
@@ -74,7 +75,7 @@ def package_to_dict(package: PackageEntry) -> Dict:
         'installed': package.installed,
         'built-in': package.built_in,
         'image-id': package.image_id,
-        'tag': package.tag,
+        'docker-image-reference': package.docker_image_reference,
     }
 
 

--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -283,7 +283,7 @@ class ServiceCreator:
             'docker_container_name': name,
             'docker_image_id': image_id,
             'docker_image_name': package.entry.repository,
-            'docker_image_tag': package.entry.tag,
+            'docker_image_reference': package.entry.docker_image_reference,
             'docker_image_run_opt': run_opt,
             'sonic_asic_platform': sonic_asic_platform
         }

--- a/sonic_package_manager/source.py
+++ b/sonic_package_manager/source.py
@@ -51,8 +51,8 @@ class PackageSource(object):
 
         image = self.install_image(package)
         package.entry.image_id = image.id
-        if image.tags:
-            package.entry.tag = image.tags[0]
+        if hasattr(image, 'tags') and image.tags:
+            package.entry.docker_image_reference = image.tags[0]
         else:
             package.entry.tag = image.id
 

--- a/sonic_package_manager/source.py
+++ b/sonic_package_manager/source.py
@@ -54,7 +54,7 @@ class PackageSource(object):
         if hasattr(image, 'tags') and image.tags:
             package.entry.docker_image_reference = image.tags[0]
         else:
-            package.entry.tag = image.id
+            package.entry.docker_image_reference = image.id
 
         # if no repository is defined for this package
         # get repository from image

--- a/tests/sonic_package_manager/conftest.py
+++ b/tests/sonic_package_manager/conftest.py
@@ -26,11 +26,15 @@ def mock_docker_api():
     @dataclass
     class Image:
         id: str
-        tags: list[str]
+        image_tags: list[str]
 
         @property
         def attrs(self):
             return {'RepoTags': [self.id]}
+
+        @property
+        def tags(self):
+            return self.image_tags
 
     def pull(repo, ref):
         return Image(f'{repo}:{ref}', [ref])

--- a/tests/sonic_package_manager/test_database.py
+++ b/tests/sonic_package_manager/test_database.py
@@ -99,7 +99,7 @@ def test_package_from_dict():
         'installed': True,
         'built-in': False,
         'image-id': 'abc123',
-        'tag': 'latest'
+        'docker-image-reference': 'latest'
     }
 
     package = package_from_dict('test-package', package_info)
@@ -112,7 +112,7 @@ def test_package_from_dict():
     assert package.installed is True
     assert package.built_in is False
     assert package.image_id == 'abc123'
-    assert package.tag == 'latest'
+    assert package.docker_image_reference == 'latest'
 
 
 def test_package_from_dict_minimal():
@@ -131,4 +131,4 @@ def test_package_from_dict_minimal():
     assert package.installed is False
     assert package.built_in is False
     assert package.image_id is None
-    assert package.tag is None
+    assert package.docker_image_reference is None

--- a/tests/sonic_package_manager/test_manager.py
+++ b/tests/sonic_package_manager/test_manager.py
@@ -626,4 +626,4 @@ def test_installation_from_file_no_tags(package_manager, mock_docker_api, sonic_
 
     # Get the package from the database and verify the tag was set to the image ID
     package = package_manager.database.get_package('test-package')
-    assert package.tag == 'Azure/docker-test:1.6.0'
+    assert package.docker_image_reference == 'Azure/docker-test:1.6.0'


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Remove non-standard docker_image_references property that was only used in test mocks

#### How I did it
Update mock Image class in conftest.py to use standard 'tags' property.

#### How to verify it
- Run all package manager tests: pytest tests/sonic_package_manager
- Install App Extension 

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

